### PR TITLE
Fix when plugin path is not specified

### DIFF
--- a/citellus.py
+++ b/citellus.py
@@ -270,6 +270,8 @@ def main():
         CITELLUS_PLUGINS = []
         for path in unknown[start:]:
             CITELLUS_PLUGINS.append(path)
+    else:
+        CITELLUS_PLUGINS = [ plugin_path ]
 
     # Save environment variables for plugins executed
     os.environ['CITELLUS_ROOT'] = "%s" % CITELLUS_ROOT


### PR DESCRIPTION
When plugin was allowed to have more than one path, the standard case of no plugin path specified was skipped.

This commit readds that behavior