### PR TITLE
Ability to make citellus silent (just output errors on scripts)

### DIFF
--- a/citellus.py
+++ b/citellus.py
@@ -218,6 +218,20 @@ def getitems(var):
     return final
 
 
+def commonpath(folders):
+    commonroot = []
+    ls = [p.split('/') for p in folders]
+    minlenght = min(len(p) for p in ls )
+
+    for i in range(minlenght):
+        s = set( p[i] for p in ls )
+        if len(s) != 1:
+            break
+        commonroot.append(s.pop())
+
+    return '/'.join(commonroot)
+
+
 def main():
     """
     Main function for the program
@@ -325,6 +339,9 @@ def main():
     # Sort plugins based on path name
     std = sorted(plugins, key=lambda file: (os.path.dirname(file), os.path.basename(file)))
 
+    # Common path for plugins
+    common = commonpath(plugins)
+
     # Print results based on the sorted order based on returned results from parallel execution
     okay = []
     skipped = []
@@ -344,9 +361,9 @@ def main():
                     print "    %s" % line
         else:
             if 'okay' in text:
-                okay.append(plugin['plugin'])
+                okay.append(plugin['plugin'].replace(common,''))
             if 'skipped' in text:
-                skipped.append(plugin['plugin'])
+                skipped.append(plugin['plugin'].replace(common,''))
 
         logger.debug(msg=_("Plugin: %s, output: %s") % (plugin['plugin'], plugin['output']))
 

--- a/citellus.py
+++ b/citellus.py
@@ -326,6 +326,8 @@ def main():
     std = sorted(plugins, key=lambda file: (os.path.dirname(file), os.path.basename(file)))
 
     # Print results based on the sorted order based on returned results from parallel execution
+    okay = []
+    skipped = []
     for i in range(0, len(std)):
         plugin = new_dict[std[i]]
 
@@ -333,15 +335,25 @@ def main():
         err = plugin['output']['err']
         text = plugin['output']['text']
         rc = plugin['output']['rc']
-        print "# %s: %s" % (plugin['plugin'], text)
 
         # If not standard RC, print stderr
         if rc != 0 and rc != 2:
+            print "# %s: %s" % (plugin['plugin'], text)
             if err != "":
                 for line in err.split('\n'):
                     print "    %s" % line
+        else:
+            if 'okay' in text:
+                okay.append(plugin['plugin'])
+            if 'skipped' in text:
+                skipped.append(plugin['plugin'])
 
         logger.debug(msg=_("Plugin: %s, output: %s") % (plugin['plugin'], plugin['output']))
+
+    if okay:
+        print "# %s: %s" % (okay, bcolors.okay)
+    if skipped:
+        print "# %s: %s" % (skipped, bcolors.skipped)
 
 
 if __name__ == "__main__":

--- a/citellus.py
+++ b/citellus.py
@@ -250,6 +250,9 @@ def main():
     p.add_argument('-d', "--verbosity", dest="verbosity",
                    help=_("Set verbosity level for messages while running/logging"),
                    default="info", choices=["info", "debug", "warn", "critical"])
+    p.add_argument("-s", "--silent", dest="silent", help=_("Enable silent mode, only errors on tests written"), default=False,
+                   action='store_true')
+
 
     options, unknown = p.parse_known_args()
 
@@ -310,8 +313,9 @@ def main():
 
     plugins = getitems(plugins)
 
-    show_logo()
-    print _("found #%s tests at %s") % (len(plugins), ", ".join(plugin_path))
+    if not options.silent:
+        show_logo()
+        print _("found #%s tests at %s") % (len(plugins), ", ".join(plugin_path))
 
     if not plugins:
         msg = _("Plugin folder empty, exitting")
@@ -319,10 +323,11 @@ def main():
         print msg
         sys.exit(1)
 
-    if CITELLUS_LIVE == 1:
-        print _("mode: live")
-    else:
-        print _("mode: fs snapshot %s" % CITELLUS_ROOT)
+    if not options.silent:
+        if CITELLUS_LIVE == 1:
+            print _("mode: live")
+        else:
+            print _("mode: fs snapshot %s" % CITELLUS_ROOT)
 
     # Set pool for same processes as CPU cores
     p = Pool(cpu_count())
@@ -367,10 +372,11 @@ def main():
 
         logger.debug(msg=_("Plugin: %s, output: %s") % (plugin['plugin'], plugin['output']))
 
-    if okay:
-        print "# %s: %s" % (okay, bcolors.okay)
-    if skipped:
-        print "# %s: %s" % (skipped, bcolors.skipped)
+    if not options.silent:
+        if okay:
+            print "# %s: %s" % (okay, bcolors.okay)
+        if skipped:
+            print "# %s: %s" % (skipped, bcolors.skipped)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
citellus --silent (or -s) will just print tests that have failed, no list of plugins found, no logos

This could make it easier for other scripts to have citellus as backend reporting

For external or UI a new mode will be needed to output all data but in some consumable form



