### PR TITLE
Do not remove common path when there's only one plugin...

### DIFF
--- a/citellus.py
+++ b/citellus.py
@@ -345,7 +345,10 @@ def main():
     std = sorted(plugins, key=lambda file: (os.path.dirname(file), os.path.basename(file)))
 
     # Common path for plugins
-    common = commonpath(plugins)
+    if len(plugins) > 1:
+        common = commonpath(plugins)
+    else:
+        common = ""
 
     # Print results based on the sorted order based on returned results from parallel execution
     okay = []


### PR DESCRIPTION
When there's only one plugin, the common path is plugin name, so it's removed from the list, and an empty string is written instead of plugin name
