### PR TITLE
Add config file for travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+python:
+    - 2.7
+
+notifications:
+    email: false
+
+before_install:
+    - pip install pep8
+    - pip install misspellings
+    - pip install python-coveralls
+
+script:
+    # Run pep8 on all .py files in all subfolders
+    # (I ignore "E402: module level import not at top of file"
+    # because of use case sys.path.append('..'); import <module>)
+    - find . -name \*.py -exec pep8 --ignore=E402,E501 {} +
+    - find . -name '*.py' | misspellings -f -
+    - nosetests
+
+after_success:
+  - coveralls


### PR DESCRIPTION
You can also, once added, register for free at travis-ci.org with github account so travis runs tests on the code.

At the moment it runs nosetests that launches the python validation (pep8, etc)

