### PR TITLE
Magui: Multiple Analisis Generic Unifier and Interpreter commit

### DIFF
--- a/citellus.py
+++ b/citellus.py
@@ -193,25 +193,7 @@ def runplugin(plugin):
         out = ""
         err = traceback.format_exc()
 
-    for case in Switch(returncode):
-        if case(0):
-            # OK
-            text = bcolors.okay
-            break
-        if case(1):
-            # FAILED
-            text = bcolors.failed
-            break
-        if case(2):
-            # SKIPPED
-            text = bcolors.skipped
-            break
-        if case():
-            # UNEXPECTED
-            text = bcolors.unexpected
-            break
-
-    return {'plugin': plugin, 'output': {"rc": returncode, "out": out, "err": err, "text": text}}
+    return {'plugin': plugin, 'output': {"rc": returncode, "out": out, "err": err}}
 
 
 def getitems(var):
@@ -289,6 +271,32 @@ def docitellus(live=False, path=False, plugins=False):
         new_dict[name] = item
 
     return new_dict
+
+
+def formattext(returncode):
+    """
+    Returns print formating for return code
+    :param returncode: return code of plugin
+    :return: formatted text for printing
+    """
+    for case in Switch(returncode):
+        if case(0):
+            # OK
+            text = bcolors.okay
+            break
+        if case(1):
+            # FAILED
+            text = bcolors.failed
+            break
+        if case(2):
+            # SKIPPED
+            text = bcolors.skipped
+            break
+        if case():
+            # UNEXPECTED
+            text = bcolors.unexpected
+            break
+    return text
 
 
 def main():
@@ -385,8 +393,8 @@ def main():
 
         out = plugin['output']['out']
         err = plugin['output']['err']
-        text = plugin['output']['text']
         rc = plugin['output']['rc']
+        text = formattext(returncode=rc)
 
         # If not standard RC, print stderr
         if (rc != 0 and rc != 2) or (options.verbose and rc == 2):

--- a/magui.py
+++ b/magui.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# Description: Multiple Analysis Generic Unifier and Interpreter aka Magui
+#              This program processes several snapshoot/sosreport files
+#              and processes citellus output for combined issues via plugins
+#              that search for specific plugin and data
+#
+# Copyright (C) 2017  Pablo Iranzo Gómez (Pablo.Iranzo@redhat.com)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import citellus
+import argparse
+import gettext
+import logging
+import os
+import os.path
+import subprocess
+import sys
+import traceback
+from multiprocessing import Pool, cpu_count
+
+# Where are we?
+maguidir = os.path.abspath(os.path.dirname(__file__))
+localedir = os.path.join(maguidir, 'locale')
+
+trad = gettext.translation('magui', localedir, fallback=True)
+_ = trad.ugettext
+
+
+def show_logo():
+    """
+    Prints Magui Logo
+    :return:
+    """
+
+    logo = "    _    ", \
+           "  _( )_  Magui:", \
+           " (_(ø)_) ",\
+           "  /(_)   Multiple Analisis Generic Unifier and Interpreter", \
+           " \|      ", \
+           "  |/     " \
+
+    for line in logo:
+        print line
+
+
+def main():
+    description = _('Processes several generic archives/sosreports scripts in a uniform way, to interpret status that depend on several systems data')
+
+    # Option parsing
+    p = argparse.ArgumentParser("magui.py [arguments]", description=description)
+    p.add_argument('-d', "--verbosity", dest="verbosity",
+                   help=_("Set verbosity level for messages while running/logging"),
+                   default="info", choices=["info", "debug", "warn", "critical"])
+    p.add_argument('-p', "--pluginpath", dest="pluginpath",
+                   help=_("Set path for Citellus plugin location if not default"),
+                   action='append')
+    p.add_argument('-m', "--mpath", dest="mpath",
+                   help=_("Set path for Magui plugin location if not default"),
+                   action='append')
+    p.add_argument("-s", "--silent", dest="silent", help=_("Enable silent mode, only errors on tests written"),
+                   default=False,
+                   action='store_true')
+    p.add_argument("-f", "--filter", dest="filter",
+                   help=_("Only include Citellus plugins that contains in full path that substring"),
+                   default=False)
+    p.add_argument("-mf", "--mfilter", dest="mfilter",
+                   help=_("Only include Magui plugins that contains in full path that substring"),
+                   default=False)
+
+    options, unknown = p.parse_known_args()
+
+    # Configure logging
+    logging.basicConfig(level=citellus.conflogging(verbosity=options.verbosity))
+
+    logger = logging.getLogger(__name__)
+
+    plugin_path = os.path.join(maguidir, 'magplug')
+
+
+    if not options.silent:
+        show_logo()
+
+    # Each argument in unknown is a sosreport
+
+    # Grab data from citellus for the sosreports provided
+    results = {}
+    for sosreport in unknown:
+        if not options.silent:
+            print _("Gathering analysis for %s") % sosreport
+        results[sosreport] = citellus.docitellus(live=False, path=sosreport, plugins=citellus.findplugins(filter=options.filter))
+
+    # Precreate multidimensional array
+    grouped = {}
+    for sosreport in unknown:
+        for plugin in results[sosreport]:
+            grouped[plugin] = {}
+
+
+    # Fill the data
+    for sosreport in unknown:
+        for plugin in results[sosreport]:
+            grouped[plugin][sosreport] = results[sosreport][plugin]['output']
+
+    # We've now a matrix of grouped[plugin][sosreport] and then [text] [out] [err] [rc]
+    print grouped
+
+    # We need to run our plugins against that data
+
+    # TODO(iranzo): write code for processing plugins once decided what to use and process (rather than feding above data outputed to the full scripts)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Magui aggregates data obtained from citellus and its plugins, it aims to generate information based on the analysys from the data.

Plugins are still in the work once decided the way to do it properly

Example test run:

~~~
[user@host folder]$ ~/citellus/magui.py -f seqno *
    _    
  _( )_  Magui:
 (_(ø)_) 
  /(_)   Multiple Analisis Generic Unifier and Interpreter
 \|      
  |/     
Gathering analysis for ctrl0.localdomain
Gathering analysis for ctrl1.localdomain
Gathering analysis for ctrl2.localdomain
{'/home/remote/piranzo/citellus/plugins/openstack/mysql/seqno.sh': {'ctrl2.localdomain': {'rc': 0, 'err': '08a94e67-bae0-11e6-8239-9a6188749d23:36117633\n', 'out': ''}, 'ctrl1.localdomain': {'rc': 0, 'err': '08a94e67-bae0-11e6-8239-9a6188749d23:36117633\n', 'out': ''}, 'ctrl0.localdomain': {'rc': 0, 'err': '08a94e67-bae0-11e6-8239-9a6188749d23:36117633\n', 'out': ''}}}

~~~

In this case, it reports 'database' seqno and uuid (as obtained from `seqno`) plugin by citellus, but grouping under 'plugin'.

Target is to later allow to process that data based on plugins for magui that allow to only process the plugins that are of interest for specific test, and compare results across obtained on different hosts
