### PR TITLE
system tests: new tests and cleanups

### DIFF
--- a/citellus/citellus.py
+++ b/citellus/citellus.py
@@ -40,7 +40,11 @@ citellusdir = os.path.abspath(os.path.dirname(__file__))
 localedir = os.path.join(citellusdir, 'locale')
 
 trad = gettext.translation('citellus', localedir, fallback=True)
-_ = trad.ugettext
+
+try:
+    _ = trad.ugettext
+except AttributeError:
+    _ = trad.gettext
 
 
 class bcolors:
@@ -129,7 +133,10 @@ def runplugin(plugin):
         out = ""
         err = traceback.format_exc()
 
-    return {'plugin': plugin, 'output': {"rc": returncode, "out": out, "err": err}}
+    return {'plugin': plugin,
+            'output': {"rc": returncode,
+                       "out": out.decode('ascii', 'ignore'),
+                       "err": err.decode('ascii', 'ignore')}}
 
 
 def commonpath(folders):
@@ -301,7 +308,7 @@ def main():
         if (rc != 0 and rc != 2) or (options.verbose and rc == 2):
             print("# %s: %s" % (plugin['plugin'], text))
             if err != "":
-                for line in err.split('\n'):
+                for line in err.splitlines():
                     print("    %s" % line)
         else:
             if 'okay' in text:

--- a/citellus/plugins/system/clock-1-ntpd.sh
+++ b/citellus/plugins/system/clock-1-ntpd.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Copyright (C) 2017   Robin Cernin (rcernin@redhat.com)
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# adapted from https://github.com/larsks/platypus/blob/master/bats/system/test_clock.bats
+
+: ${CITELLUS_MAX_CLOCK_OFFSET:=1}
+
+is_active() {
+    systemctl is-active "$@" > /dev/null 2>&1
+}
+
+if [[ $CITELLUS_LIVE = 0 ]]; then
+  echo "works on live-system only" >&2
+  exit 2
+fi
+
+if ! is_active ntpd; then
+    echo "ntpd is not active" >&2
+    exit 2
+fi
+
+if ! [[ -x /usr/bin/bc ]]; then
+    echo "this check requires /usr/bin/bc" >&2
+    exit 2
+fi
+
+if ! out=$(ntpq -c peers); then
+    echo "failed to contact ntpd" >&2
+    exit 1
+fi
+
+if ! awk '/^\*/ {sync=1} END {exit ! sync}' <<<"$out"; then
+    echo "clock is not synchronized" >&2
+    return 1
+fi
+
+offset=$(awk '/^\*/ {print $9/1000}' <<<"$out")
+echo "clock offset is $offset" >&2
+
+((
+$(echo "$offset<${CITELLUS_MAX_CLOCK_OFFSET:-1} && \
+    $offset>-${CITELLUS_MAX_CLOCK_OFFSET:-1}" | bc -l)
+))

--- a/citellus/plugins/system/hardware_virtualization.sh
+++ b/citellus/plugins/system/hardware_virtualization.sh
@@ -22,4 +22,7 @@ if [ ! -f "${CITELLUS_ROOT}/proc/cpuinfo" ]; then
   exit 2
 fi
 
-grep -q "svm\|vmx" "${CITELLUS_ROOT}/proc/cpuinfo"
+if ! grep -q "svm\|vmx" "${CITELLUS_ROOT}/proc/cpuinfo"; then
+	echo "no hardware virt support found in /proc/cpuinfo" >&2
+	exit 1
+fi

--- a/citellus/plugins/system/selinux_runtime.sh
+++ b/citellus/plugins/system/selinux_runtime.sh
@@ -17,14 +17,25 @@
 
 # selinux enforcing
 
-if [ "x$CITELLUS_LIVE" = "x0" ];  then
-  if [ ! -f "${CITELLUS_ROOT}/sos_commands/selinux/sestatus_-b" ]; then
-    echo "file /sos_commands/selinux/sestatus_-b not found." >&2
-    exit 2
-  fi
-  grep -q "^Current mode.*enforcing" "${CITELLUS_ROOT}/sos_commands/selinux/sestatus_-b" || exit 1
-elif [ "x$CITELLUS_LIVE" = "x1" ]; then
-  if ! sestatus -b | grep -q "^Current mode.*enforcing"; then
+if [[ $CITELLUS_LIVE = 0 ]];  then
+    path="${CITELLUS_ROOT}/sos_commands/selinux/sestatus_-b"
+
+    if [ ! -f "$path" ]; then
+        echo "file $path not found." >&2
+        exit 2
+    fi
+
+    mode=$(awk '/^Current mode:/ {print $3}' "$path")
+else
+    mode=$(sestatus -b | awk '/^Current mode:/ {print $3}')
+fi
+
+if ! [[ "$mode" ]]; then
+    echo "failed to determined runtime selinux mode" >&2
     exit 1
-  fi
+fi
+
+if [[ $mode != enforcing ]]; then
+    echo "runtime selinux mode is not enforcing (found $mode)" >&2
+    exit 1
 fi

--- a/citellus/plugins/system/updates.sh
+++ b/citellus/plugins/system/updates.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2017   Robin Cernin (rcernin@redhat.com)
+# Copyright (C) 2017 Red Hat, Inc.
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,27 +15,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# error if disk usage is greater than $CITELLUS_DISK_MAX_PERCENT
-
-: ${CITELLUS_DISK_MAX_PERCENT=75}
-
-if [[ $CITELLUS_LIVE = 0 ]];  then
-  if [[ ! -f ${CITELLUS_ROOT}/df ]]; then
-    echo "file /df not found." >&2
-    exit 2
-  fi
-  DISK_USE_CMD="cat ${CITELLUS_ROOT}/df"
-else
-  DISK_USE_CMD="df -P"
+if [[ $CITELLUS_LIVE = 0 ]]; then
+  echo "works on live-system only" >&2
+  exit 2
 fi
 
-result=$($DISK_USE_CMD |
-	awk -vdisk_max_percent=$CITELLUS_DISK_MAX_PERCENT \
-	'/^\/dev/ && substr($5, 0, length($5)-1) > disk_max_percent {
-		print $6,$5
-	}')
+yum check-update 2> /dev/null
 
-if [ -n "$result" ]; then
-  echo "${result}" >&2
-  exit 1
+if [[ $? -eq 100 ]]; then
+    echo "there are available uninstalled upgrades" >&2
+    exit 1
+elif [[ $? -ne 0 ]]; then
+    echo "failed to check available updates" >&2
+    exit 1
 fi


### PR DESCRIPTION
this commit introduces two new tests:

- updates.sh checks for uninstalled package updates.
- clock-0-ntp-services.sh checks to be sure that one of ntpd or
 chronyd is enabled

it also makes changes to the behavior of several existing tests:

- only check explicitly for CITELLUS_LIVE=0, which makes them easier
 to run manually.
- always provide some informative text in the event of a failure.

Note that this PR is on top of #82, so it includes that commit as well.