### PR TITLE
fix incorrect function call

### DIFF
--- a/citellusclient/plugins/core/system/vfs-cache-pressure.sh
+++ b/citellusclient/plugins/core/system/vfs-cache-pressure.sh
@@ -31,7 +31,7 @@ elif [[ "x$CITELLUS_LIVE" = "x1" ]]; then
     trap "rm ${FILE}" EXIT
 fi
 
-is_file_required "${FILE}"
+is_required_file "${FILE}"
 
 VALUE=$(grep vm.vfs_cache_pressure ${FILE}|cut -d "=" -f 2)
 


### PR DESCRIPTION
```
# /home/george/git/citellus/citellusclient/plugins/core/system/vfs-cache-pressure.sh: failed [critical]
    /home/george/git/citellus/citellusclient/plugins/core/system/vfs-cache-pressure.sh: line 34: is_file_required: command not found
    High vfs_cache_pressure
```