### PR TITLE
is_rpm: fixed RPM not being found

### DIFF
--- a/citellusclient/common.d/01-rpm.sh
+++ b/citellusclient/common.d/01-rpm.sh
@@ -19,7 +19,7 @@
 
 is_rpm(){
     if [ "x$CITELLUS_LIVE" = "x1" ]; then
-        rpm -qa *$1*|egrep ^"$1"-[0-9]
+        rpm -qa \*$1\*|egrep ^"$1"-[0-9]
     elif [ "x$CITELLUS_LIVE" = "x0" ]; then
         is_required_file "${CITELLUS_ROOT}/installed-rpms"
         awk '{print $1}' "${CITELLUS_ROOT}/installed-rpms"|egrep ^"$1"-[0-9]


### PR DESCRIPTION
On live system, `is_required_pkg freeradius` was not finding the package.
Looks like the star `*` must be escaped.
Also, we may get rid off the first star since the `egrep` being made checks for name starting with package name anyway.