### PR TITLE
Firewalld plugin added

### DIFF
--- a/citellusclient/plugins/core/system/firewall.sh
+++ b/citellusclient/plugins/core/system/firewall.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Copyright (C) 2018 Juan Manuel Parrilla (jparrill@redhat.com)
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# check iptables || check firewalld
+
+# Load common functions
+[[ -f "${CITELLUS_BASE}/common-functions.sh" ]] && . "${CITELLUS_BASE}/common-functions.sh"
+
+# long_name: Validate RHEL Firewall
+# description: Validate RHEL firewall and check if is up
+# priority: 200
+
+function validate_firewall {
+    # Check linux firewall to validate if it's running and active
+    if is_active $1; then
+        # True when service is up
+        _SERVICE=0
+    else
+        # False when service is down
+        _SERVICE=1
+    fi
+
+    echo ${_SERVICE}
+}
+
+OS=`discover_os`
+
+if [[ "$OS" == "debian" ]] || [[ "$OS" == "fedora" ]]; then
+    _FW='firewalld'
+else
+    RH_RELEASE=`discover_rhrelease`
+    case ${RH_RELEASE} in
+        6) _FW='iptables' ;;
+        7) _FW='firewalld' ;;
+        0) _FW='undef' ;;
+    esac
+fi
+
+_STATUS=`validate_firewall "${_FW}"`
+
+if [[ $_STATUS -eq 0 ]]; then
+    exit ${RC_OKAY}
+else
+    echo "Service ${_FW} not active: ${_STATUS}" >&2
+    exit ${RC_FAILED}
+fi


### PR DESCRIPTION
Fixing Issue #612 

On Success: 
```
[root@acheron citellus] # ./citellus.py -l -i firewall -v
_________ .__  __         .__  .__                
\_   ___ \|__|/  |_  ____ |  | |  |  __ __  ______
/    \  \/|  \   __\/ __ \|  | |  | |  |  \/  ___/
\     \___|  ||  | \  ___/|  |_|  |_|  |  /\___ \ 
 \______  /__||__|  \___  >____/____/____//____  >
        \/              \/                     \/ 
                                                  
found #6 extensions with #2 plugins
mode: live

[l%%%l]=[]=========

# /home/jparrill/ownCloud/RedHat/RedHat_Engineering/upshift/tasks/insights/citellus/citellusclient/plugins/core/openstack/neutron/neutron-openvswitch-firewall-driver.sh: skipped
    This affects only OSP10
# /home/jparrill/ownCloud/RedHat/RedHat_Engineering/upshift/tasks/insights/citellus/citellusclient/plugins/core/system/firewall.sh: okay
```

On Error:
```
[root@acheron citellus] # ./citellus.py -l -i firewall -v
_________ .__  __         .__  .__                
\_   ___ \|__|/  |_  ____ |  | |  |  __ __  ______
/    \  \/|  \   __\/ __ \|  | |  | |  |  \/  ___/
\     \___|  ||  | \  ___/|  |_|  |_|  |  /\___ \ 
 \______  /__||__|  \___  >____/____/____//____  >
        \/              \/                     \/ 
                                                  
found #6 extensions with #2 plugins
mode: live

[l%%%l]=[]=========

# /home/jparrill/ownCloud/RedHat/RedHat_Engineering/upshift/tasks/insights/citellus/citellusclient/plugins/core/openstack/neutron/neutron-openvswitch-firewall-driver.sh: skipped
    This affects only OSP10
# /home/jparrill/ownCloud/RedHat/RedHat_Engineering/upshift/tasks/insights/citellus/citellusclient/plugins/core/system/firewall.sh: failed [informative]
    Service firewalld not active: 1
```

Tox Tests:
```
  bashate: commands succeeded
  congratulations :)
```