### PR TITLE
Show local date in reports

### DIFF
--- a/risuclient/plugins/core/sysinfo/systemdate.sh
+++ b/risuclient/plugins/core/sysinfo/systemdate.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright (C) 2022 Pablo Iranzo Gómez <Pablo.Iranzo@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# long_name: reports system date
+# description: reports system date
+# priority: 100
+
+# Load common functions
+[[ -f "${RISU_BASE}/common-functions.sh" ]] && . "${RISU_BASE}/common-functions.sh"
+
+if [[ "x$RISU_LIVE" == "x0" ]]; then
+    is_required_file ${RISU_ROOT}/date
+    cat ${RISU_ROOT}/date >&2
+else
+    date >&2
+fi
+
+exit ${RC_INFO}

--- a/risuclient/shell.py
+++ b/risuclient/shell.py
@@ -1377,6 +1377,7 @@ def write_results(
 
     metadata = {
         "when": datetime.datetime.utcnow().isoformat(),
+        "whenlocal": datetime.datetime.now().isoformat(),
         "live": bool(live),
         "source": source,
         "time": time,


### PR DESCRIPTION
Adds whenlocal metadata with local timing and plugin to report as sysinfo the system date either on live or sosreport analysis

Closes #823 