### PR TITLE
style: Substitute path in plugin

### DIFF
--- a/risuclient/plugins/core/network/interface-errors.sh
+++ b/risuclient/plugins/core/network/interface-errors.sh
@@ -43,7 +43,7 @@ for iface in ${IFACES_IN_SYSTEM}; do
     for file in ${IFACEPATH}; do
         CONTENT=$(cat ${file})
         if [ $CONTENT != "0" ]; then
-            echo "$iface detected errors on $file: $CONTENT" >&2
+            echo "$iface detected errors on ${file//$RISU_ROOT/}: $CONTENT" >&2
             RC_STATUS=${RC_FAILED}
 
         fi


### PR DESCRIPTION
Substitute path to just leave iface path

![image](https://github.com/risuorg/risu/assets/312463/6208f4c2-1c1e-4de6-aacf-a5fd040d1ba0)
